### PR TITLE
Add ci_logger for CI test logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,15 @@ jobs:
       - name: Run RSpec tests
         run: bundle exec rspec
 
-      - name: Upload system test screenshots
+      - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: system-test-screenshots
+          name: test-artifacts
           if-no-files-found: ignore
           path: |
             tmp/capybara
+            log
 
   zizmor:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :test do
   gem 'timecop'
   gem 'capybara'
   gem 'capybara-email'
+  gem 'ci_logger'
   gem 'fabrication', group: :development
   gem 'accept_values_for'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
       mail
     childprocess (5.1.0)
       logger (~> 1.5)
+    ci_logger (1.1.0)
+      railties (>= 6.1.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -434,6 +436,7 @@ DEPENDENCIES
   bootsnap
   capybara
   capybara-email
+  ci_logger
   devise
   execjs
   fabrication

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.i18n.raise_on_missing_translations = true
+  config.ci_logger.enabled = ENV['CI']
   config.action_mailer.default_url_options = { host: 'localhost:3002' }
   config.assets.paths << Rails.root.join('spec', 'support', 'assets', 'stylesheets').to_s
 end


### PR DESCRIPTION
Summary: Add ci_logger in test and enable it when CI is set. Upload Rails logs with failed CI test artifacts. Tests: devcontainer exec --workspace-folder . env CI=true bundle exec rspec